### PR TITLE
bump to 0.2.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "grafeo-memory"
-version = "0.2.0"
+version = "0.2.1"
 description = "AI memory layer powered by GrafeoDB's hybrid graph and vector database"
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
This releas was:

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prepare the `grafeo-memory` 0.2.1 release by updating the version in pyproject.toml from 0.2.0 to 0.2.1.

<sup>Written for commit f42d1bd3d29156377ade3a718a461c9eb048e406. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

