### PR TITLE
Release/0.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to grafeo-memory are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.2.2] - Unreleased
+## [0.2.2] - 2026-04-08
 
 Bi-temporal validity tracking, episode-based provenance, and community summaries for richer temporal knowledge graphs.
 
@@ -30,6 +30,9 @@ Bi-temporal validity tracking, episode-based provenance, and community summaries
 - New exports: `EPISODE_LABEL`, `PRODUCED_EDGE`, `MENTIONS_EDGE`, `NEXT_EPISODE_EDGE`, `COMMUNITY_LABEL`, `HAS_MEMBER_EDGE`, `EpisodeResult`, `CommunityInfo`
 - New modules: `extraction/temporal.py`, `communities.py`
 - New prompts: `TEMPORAL_ANNOTATION_SYSTEM/USER`, `COMMUNITY_SUMMARY_SYSTEM/USER`
+- **`graph_name` scoping**: optional `graph_name` on `MemoryConfig` isolates memories and entities per subgraph when multiple callers share a database via `db=`. Stamped on all Memory and Entity creates, filtered on all read paths (`_build_filters`, `graph_search`, `temporal_chain`, session linking, `stats`). No behavior change when unset ([#23](https://github.com/GrafeoDB/grafeo-memory/issues/23), [#24](https://github.com/GrafeoDB/grafeo-memory/pull/24), thanks [@Michaelzag](https://github.com/Michaelzag))
+- `graph_name` added to property index list for fast scoped lookups
+- 15 new tests covering `graph_name` write stamping, read isolation, entity separation, stats scoping, temporal chain boundaries, and backward compatibility
 
 ### Changed
 

--- a/src/grafeo_memory/manager.py
+++ b/src/grafeo_memory/manager.py
@@ -121,7 +121,7 @@ class _MemoryCore:
             logger.debug("Text index creation deferred or already exists")
 
         # Property indexes for fast filtered lookups (database-wide; see docstring).
-        for prop in ("user_id", "created_at", "memory_type"):
+        for prop in ("user_id", "created_at", "memory_type", "graph_name"):
             with contextlib.suppress(Exception):
                 self._db.create_property_index(prop)
         with contextlib.suppress(Exception):
@@ -157,12 +157,14 @@ class _MemoryCore:
     # --- Scope filter building ---
 
     def _build_filters(self, user_id: str, extra: dict | None = None) -> dict:
-        """Build query filters from config scoping (user_id, agent_id, run_id)."""
+        """Build query filters from config scoping (user_id, agent_id, run_id, graph_name)."""
         filters: dict = {"user_id": user_id}
         if self._config.agent_id:
             filters["agent_id"] = self._config.agent_id
         if self._config.run_id:
             filters["run_id"] = self._config.run_id
+        if self._config.graph_name:
+            filters["graph_name"] = self._config.graph_name
         if extra:
             filters.update(extra)
         return filters
@@ -401,6 +403,8 @@ class _MemoryCore:
                 props["agent_id"] = self._config.agent_id
             if self._config.run_id:
                 props["run_id"] = self._config.run_id
+            if self._config.graph_name:
+                props["graph_name"] = self._config.graph_name
             if actor_id:
                 props["actor_id"] = actor_id
             if role:
@@ -609,6 +613,7 @@ class _MemoryCore:
             _entities=entities,
             query_embedding=query_embedding,
             search_depth=self._config.graph_search_depth,
+            graph_name=self._config.graph_name,
         )
 
         # Post-hoc filter graph results by memory_type if specified
@@ -1007,6 +1012,8 @@ class _MemoryCore:
             props["agent_id"] = self._config.agent_id
         if self._config.run_id:
             props["run_id"] = self._config.run_id
+        if self._config.graph_name:
+            props["graph_name"] = self._config.graph_name
         if actor_id:
             props["actor_id"] = actor_id
         if role:
@@ -1127,6 +1134,8 @@ class _MemoryCore:
                 continue
             if props.get("user_id") != user_id:
                 continue
+            if self._config.graph_name and props.get("graph_name") != self._config.graph_name:
+                continue
             node_run = props.get("run_id") or props.get("session_id")
             if node_run != run_id:
                 continue
@@ -1171,16 +1180,19 @@ class _MemoryCore:
         """
         mid = int(memory_id)
         user_filter = " AND rest.user_id = $uid" if user_id else ""
+        graph_filter = " AND rest.graph_name = $gn" if self._config.graph_name else ""
         params: dict = {"mid": mid}
         if user_id:
             params["uid"] = user_id
+        if self._config.graph_name:
+            params["gn"] = self._config.graph_name
 
         results: list[dict] = []
 
         if direction in ("forward", "both"):
             query = (
                 f"MATCH (m:{MEMORY_LABEL})-[:{LEADS_TO_EDGE}*1..{max_depth}]->(rest:{MEMORY_LABEL}) "
-                f"WHERE id(m) = $mid{user_filter} "
+                f"WHERE id(m) = $mid{user_filter}{graph_filter} "
                 f"RETURN id(rest), rest.text, rest.created_at, rest.session_id "
                 f"ORDER BY rest.created_at"
             )
@@ -1210,7 +1222,7 @@ class _MemoryCore:
         if direction in ("backward", "both"):
             query = (
                 f"MATCH (rest:{MEMORY_LABEL})-[:{LEADS_TO_EDGE}*1..{max_depth}]->(m:{MEMORY_LABEL}) "
-                f"WHERE id(m) = $mid{user_filter} "
+                f"WHERE id(m) = $mid{user_filter}{graph_filter} "
                 f"RETURN id(rest), rest.text, rest.created_at, rest.session_id "
                 f"ORDER BY rest.created_at"
             )
@@ -1357,10 +1369,14 @@ class _MemoryCore:
 
     def _find_or_create_entity(self, entity: Entity, user_id: str) -> int:
         try:
-            rows = self._db.execute(
-                f"MATCH (e:{ENTITY_LABEL}) WHERE e.name = $name AND e.user_id = $uid RETURN id(e)",
-                {"name": entity.name, "uid": user_id},
-            )
+            gn = self._config.graph_name
+            if gn:
+                query = f"MATCH (e:{ENTITY_LABEL}) WHERE e.name = $name AND e.user_id = $uid AND e.graph_name = $gn RETURN id(e)"
+                params = {"name": entity.name, "uid": user_id, "gn": gn}
+            else:
+                query = f"MATCH (e:{ENTITY_LABEL}) WHERE e.name = $name AND e.user_id = $uid RETURN id(e)"
+                params = {"name": entity.name, "uid": user_id}
+            rows = self._db.execute(query, params)
             for row in rows:
                 if isinstance(row, dict):
                     vals = list(row.values())
@@ -1369,10 +1385,10 @@ class _MemoryCore:
         except Exception:
             logger.warning("_find_or_create_entity: lookup failed for %r", entity.name, exc_info=True)
 
-        node = self._db.create_node(
-            [ENTITY_LABEL],
-            {"name": entity.name, "entity_type": entity.entity_type, "user_id": user_id},
-        )
+        entity_props: dict = {"name": entity.name, "entity_type": entity.entity_type, "user_id": user_id}
+        if self._config.graph_name:
+            entity_props["graph_name"] = self._config.graph_name
+        node = self._db.create_node([ENTITY_LABEL], entity_props)
         return node.id if hasattr(node, "id") else node
 
     def _get_existing_relations(self, entity_ids: dict[str, int]) -> list[dict]:
@@ -1589,6 +1605,7 @@ class _MemoryCore:
 
     def _stats_impl(self) -> MemoryStats:
         """Collect database introspection statistics."""
+        gn = self._config.graph_name
         try:
             memory_nodes = self._db.get_nodes_by_label(MEMORY_LABEL)
         except Exception:
@@ -1600,6 +1617,8 @@ class _MemoryCore:
         for item in memory_nodes:
             # get_nodes_by_label returns list of (id, props_dict) tuples
             props = item[1] if isinstance(item, tuple) else _get_props(item)
+            if gn and props.get("graph_name") != gn:
+                continue
             mtype = props.get("memory_type", "semantic")
             if mtype == "procedural":
                 procedural += 1
@@ -1610,15 +1629,28 @@ class _MemoryCore:
 
         try:
             entity_nodes = self._db.get_nodes_by_label(ENTITY_LABEL)
-            entity_count = len(entity_nodes)
+            if gn:
+                entity_count = sum(
+                    1 for item in entity_nodes
+                    if (item[1] if isinstance(item, tuple) else _get_props(item)).get("graph_name") == gn
+                )
+            else:
+                entity_count = len(entity_nodes)
         except Exception:
             entity_count = 0
 
         relation_count = 0
         try:
-            rows = self._db.execute(
-                f"MATCH (:{ENTITY_LABEL})-[r:{RELATION_EDGE}]->(:{ENTITY_LABEL}) RETURN count(r)", {}
-            )
+            if gn:
+                rows = self._db.execute(
+                    f"MATCH (s:{ENTITY_LABEL})-[r:{RELATION_EDGE}]->(t:{ENTITY_LABEL}) "
+                    f"WHERE s.graph_name = $gn RETURN count(r)",
+                    {"gn": gn},
+                )
+            else:
+                rows = self._db.execute(
+                    f"MATCH (:{ENTITY_LABEL})-[r:{RELATION_EDGE}]->(:{ENTITY_LABEL}) RETURN count(r)", {}
+                )
             for row in rows:
                 vals = list(row.values()) if isinstance(row, dict) else [row]
                 relation_count = int(vals[0]) if vals else 0

--- a/src/grafeo_memory/manager.py
+++ b/src/grafeo_memory/manager.py
@@ -1951,7 +1951,8 @@ class _MemoryCore:
             entity_nodes = self._db.get_nodes_by_label(ENTITY_LABEL)
             if gn:
                 entity_count = sum(
-                    1 for item in entity_nodes
+                    1
+                    for item in entity_nodes
                     if (item[1] if isinstance(item, tuple) else _get_props(item)).get("graph_name") == gn
                 )
             else:

--- a/src/grafeo_memory/manager.py
+++ b/src/grafeo_memory/manager.py
@@ -1371,7 +1371,10 @@ class _MemoryCore:
         try:
             gn = self._config.graph_name
             if gn:
-                query = f"MATCH (e:{ENTITY_LABEL}) WHERE e.name = $name AND e.user_id = $uid AND e.graph_name = $gn RETURN id(e)"
+                query = (
+                    f"MATCH (e:{ENTITY_LABEL}) WHERE e.name = $name AND e.user_id = $uid "
+                    f"AND e.graph_name = $gn RETURN id(e)"
+                )
                 params = {"name": entity.name, "uid": user_id, "gn": gn}
             else:
                 query = f"MATCH (e:{ENTITY_LABEL}) WHERE e.name = $name AND e.user_id = $uid RETURN id(e)"

--- a/src/grafeo_memory/search/graph.py
+++ b/src/grafeo_memory/search/graph.py
@@ -100,7 +100,8 @@ def graph_search(
             with contextlib.suppress(Exception):
                 params = {"name": entity.name.lower(), "uid": user_id, **gn_params}
                 rows = db.execute(
-                    f"MATCH (e:{ENTITY_LABEL}) WHERE toLower(e.name) = $name AND e.user_id = $uid{gn_filter} RETURN id(e)",
+                    f"MATCH (e:{ENTITY_LABEL}) WHERE toLower(e.name) = $name "
+                    f"AND e.user_id = $uid{gn_filter} RETURN id(e)",
                     params,
                 )
                 entity_nids = [int(next(iter(r.values()))) for r in rows if isinstance(r, dict) and r]

--- a/src/grafeo_memory/search/graph.py
+++ b/src/grafeo_memory/search/graph.py
@@ -44,6 +44,7 @@ def graph_search(
     _entities: list | None = None,
     query_embedding: list[float] | None = None,
     search_depth: int = 1,
+    graph_name: str | None = None,
 ) -> list[SearchResult]:
     """Search by extracting entities from the query and finding linked memories.
 
@@ -78,13 +79,17 @@ def graph_search(
     results: list[SearchResult] = []
     seen_memory_ids: set[str] = set()
 
+    gn_filter = " AND e.graph_name = $gn" if graph_name else ""
+    gn_params: dict = {"gn": graph_name} if graph_name else {}
+
     for entity in entities:
         # Find Entity nodes by name, scoped to the Entity label and user.
         entity_nids: list[int] = []
         try:
+            params = {"name": entity.name, "uid": user_id, **gn_params}
             rows = db.execute(
-                f"MATCH (e:{ENTITY_LABEL}) WHERE e.name = $name AND e.user_id = $uid RETURN id(e)",
-                {"name": entity.name, "uid": user_id},
+                f"MATCH (e:{ENTITY_LABEL}) WHERE e.name = $name AND e.user_id = $uid{gn_filter} RETURN id(e)",
+                params,
             )
             entity_nids = [int(next(iter(r.values()))) for r in rows if isinstance(r, dict) and r]
         except Exception:
@@ -93,22 +98,24 @@ def graph_search(
         # Case-insensitive fallback
         if not entity_nids:
             with contextlib.suppress(Exception):
+                params = {"name": entity.name.lower(), "uid": user_id, **gn_params}
                 rows = db.execute(
-                    f"MATCH (e:{ENTITY_LABEL}) WHERE toLower(e.name) = $name AND e.user_id = $uid RETURN id(e)",
-                    {"name": entity.name.lower(), "uid": user_id},
+                    f"MATCH (e:{ENTITY_LABEL}) WHERE toLower(e.name) = $name AND e.user_id = $uid{gn_filter} RETURN id(e)",
+                    params,
                 )
                 entity_nids = [int(next(iter(r.values()))) for r in rows if isinstance(r, dict) and r]
 
+        mem_gn_filter = " AND m.graph_name = $gn" if graph_name else ""
         for entity_nid in entity_nids:
             # Traverse HAS_ENTITY edges back to Memory nodes
             try:
                 query_str = (
                     f"MATCH (m:{MEMORY_LABEL})"
                     f"-[:{HAS_ENTITY_EDGE}]->(e:{ENTITY_LABEL}) "
-                    f"WHERE id(e) = $eid AND m.user_id = $uid "
+                    f"WHERE id(e) = $eid AND m.user_id = $uid{mem_gn_filter} "
                     f"RETURN id(m), m.text"
                 )
-                result = db.execute(query_str, {"eid": entity_nid, "uid": user_id})
+                result = db.execute(query_str, {"eid": entity_nid, "uid": user_id, **gn_params})
                 for row in result:
                     if not isinstance(row, dict):
                         continue
@@ -158,13 +165,14 @@ def graph_search(
     if search_depth >= 2 and entities:
         entity_names = [e.name for e in entities]
         try:
+            two_hop_gn = " AND e1.graph_name = $gn AND m.graph_name = $gn" if graph_name else ""
             two_hop_query = (
                 f"MATCH (e1:{ENTITY_LABEL})-[:{RELATION_EDGE}]->(e2:{ENTITY_LABEL})"
                 f"<-[:{HAS_ENTITY_EDGE}]-(m:{MEMORY_LABEL}) "
-                f"WHERE e1.name IN $names AND e1.user_id = $uid AND m.user_id = $uid "
+                f"WHERE e1.name IN $names AND e1.user_id = $uid AND m.user_id = $uid{two_hop_gn} "
                 f"RETURN DISTINCT id(m), m.text"
             )
-            two_hop_result = db.execute(two_hop_query, {"names": entity_names, "uid": user_id})
+            two_hop_result = db.execute(two_hop_query, {"names": entity_names, "uid": user_id, **gn_params})
             for row in two_hop_result:
                 if not isinstance(row, dict):
                     continue

--- a/src/grafeo_memory/search/graph.py
+++ b/src/grafeo_memory/search/graph.py
@@ -166,7 +166,7 @@ def graph_search(
     if search_depth >= 2 and entities:
         entity_names = [e.name for e in entities]
         try:
-            two_hop_gn = " AND e1.graph_name = $gn AND m.graph_name = $gn" if graph_name else ""
+            two_hop_gn = " AND e1.graph_name = $gn AND e2.graph_name = $gn AND m.graph_name = $gn" if graph_name else ""
             two_hop_query = (
                 f"MATCH (e1:{ENTITY_LABEL})-[:{RELATION_EDGE}]->(e2:{ENTITY_LABEL})"
                 f"<-[:{HAS_ENTITY_EDGE}]-(m:{MEMORY_LABEL}) "

--- a/src/grafeo_memory/types.py
+++ b/src/grafeo_memory/types.py
@@ -55,6 +55,7 @@ class MemoryConfig:
     session_id: str | None = None
     agent_id: str | None = None
     run_id: str | None = None
+    graph_name: str | None = None
     reconciliation_threshold: float = 0.3
     search_min_score: float = 0.0
     agreement_bonus: float = 0.1

--- a/tests/test_graph_name.py
+++ b/tests/test_graph_name.py
@@ -1,0 +1,298 @@
+"""Tests for graph_name scoping in MemoryConfig.
+
+Two MemoryManagers sharing a single GrafeoDB instance, each with a
+different graph_name, should be fully isolated: memories, entities,
+search results, stats, and temporal chains should not bleed across.
+"""
+
+import grafeo
+from mock_llm import MockEmbedder, make_test_model
+
+from grafeo_memory import MemoryAction, MemoryConfig, MemoryManager
+from grafeo_memory.search.vector import _get_props
+from grafeo_memory.types import ENTITY_LABEL, MEMORY_LABEL
+
+
+def _extraction(facts=None, entities=None, relations=None):
+    return {
+        "facts": facts or ["alice works at acme corp"],
+        "entities": entities
+        or [
+            {"name": "alice", "entity_type": "person"},
+            {"name": "acme_corp", "entity_type": "organization"},
+        ],
+        "relations": relations or [{"source": "alice", "target": "acme_corp", "relation_type": "works_at"}],
+    }
+
+
+def _make_manager(db, graph_name, outputs, dims=16, **kwargs):
+    model = make_test_model(outputs)
+    embedder = MockEmbedder(dims)
+    defaults = {
+        "db_path": None,
+        "user_id": "test_user",
+        "embedding_dimensions": dims,
+        "graph_name": graph_name,
+    }
+    defaults.update(kwargs)
+    config = MemoryConfig(**defaults)
+    return MemoryManager(model, config, embedder=embedder, db=db)
+
+
+class TestGraphNameWriteScoping:
+    """Nodes created under a graph_name carry the property."""
+
+    def test_memory_node_stamped_with_graph_name(self):
+        db = grafeo.GrafeoDB()
+        mgr = _make_manager(db, "design_a", [_extraction()])
+        mgr.add("Alice works at Acme Corp")
+
+        for _nid, props in db.get_nodes_by_label(MEMORY_LABEL):
+            assert props.get("graph_name") == "design_a"
+
+        mgr.close()
+
+    def test_entity_node_stamped_with_graph_name(self):
+        db = grafeo.GrafeoDB()
+        mgr = _make_manager(db, "design_a", [_extraction()])
+        mgr.add("Alice works at Acme Corp")
+
+        for _nid, props in db.get_nodes_by_label(ENTITY_LABEL):
+            assert props.get("graph_name") == "design_a"
+
+        mgr.close()
+
+    def test_no_graph_name_means_no_property(self):
+        db = grafeo.GrafeoDB()
+        mgr = _make_manager(db, None, [_extraction()])
+        mgr.add("Alice works at Acme Corp")
+
+        for _nid, props in db.get_nodes_by_label(MEMORY_LABEL):
+            assert "graph_name" not in props
+
+        for _nid, props in db.get_nodes_by_label(ENTITY_LABEL):
+            assert "graph_name" not in props
+
+        mgr.close()
+
+    def test_batch_add_stamps_graph_name(self):
+        db = grafeo.GrafeoDB()
+        mgr = _make_manager(db, "batch_graph", [_extraction()])
+        mgr.add("Alice works at Acme Corp", infer=False)
+
+        for _nid, props in db.get_nodes_by_label(MEMORY_LABEL):
+            assert props.get("graph_name") == "batch_graph"
+
+        mgr.close()
+
+
+class TestGraphNameReadIsolation:
+    """Queries from one graph_name must not see nodes from another."""
+
+    def test_search_isolated_between_graphs(self):
+        db = grafeo.GrafeoDB()
+        mgr_a = _make_manager(db, "graph_a", [_extraction()])
+        mgr_b = _make_manager(db, "graph_b", [
+            _extraction(facts=["bob likes hiking"], entities=[{"name": "bob", "entity_type": "person"}], relations=[]),
+        ])
+
+        mgr_a.add("Alice works at Acme Corp")
+        mgr_b.add("Bob likes hiking")
+
+        results_a = mgr_a.search("Alice", user_id="test_user")
+        results_b = mgr_b.search("Bob", user_id="test_user")
+
+        texts_a = [r.text for r in results_a]
+        texts_b = [r.text for r in results_b]
+
+        # graph_a should only see alice's memory
+        assert any("alice" in t.lower() or "acme" in t.lower() for t in texts_a)
+        assert not any("bob" in t.lower() or "hiking" in t.lower() for t in texts_a)
+
+        # graph_b should only see bob's memory
+        assert any("bob" in t.lower() or "hiking" in t.lower() for t in texts_b)
+        assert not any("alice" in t.lower() or "acme" in t.lower() for t in texts_b)
+
+        mgr_a.close()
+        mgr_b.close()
+
+    def test_get_all_isolated_between_graphs(self):
+        db = grafeo.GrafeoDB()
+        mgr_a = _make_manager(db, "graph_a", [_extraction()])
+        mgr_b = _make_manager(db, "graph_b", [
+            _extraction(facts=["bob likes hiking"], entities=[{"name": "bob", "entity_type": "person"}], relations=[]),
+        ])
+
+        mgr_a.add("Alice works at Acme Corp")
+        mgr_b.add("Bob likes hiking")
+
+        all_a = mgr_a.get_all(user_id="test_user")
+        all_b = mgr_b.get_all(user_id="test_user")
+
+        assert len(all_a) == 1
+        assert len(all_b) == 1
+        assert "alice" in all_a[0].text.lower() or "acme" in all_a[0].text.lower()
+        assert "bob" in all_b[0].text.lower() or "hiking" in all_b[0].text.lower()
+
+        mgr_a.close()
+        mgr_b.close()
+
+    def test_no_graph_name_sees_everything(self):
+        db = grafeo.GrafeoDB()
+        mgr_a = _make_manager(db, "graph_a", [_extraction()])
+        mgr_b = _make_manager(db, "graph_b", [
+            _extraction(facts=["bob likes hiking"], entities=[{"name": "bob", "entity_type": "person"}], relations=[]),
+        ])
+        mgr_all = _make_manager(db, None, [])
+
+        mgr_a.add("Alice works at Acme Corp")
+        mgr_b.add("Bob likes hiking")
+
+        all_memories = mgr_all.get_all(user_id="test_user")
+        assert len(all_memories) == 2
+
+        mgr_a.close()
+        mgr_b.close()
+        mgr_all.close()
+
+
+class TestGraphNameEntityIsolation:
+    """Same entity name in different graphs should be separate nodes."""
+
+    def test_same_entity_different_graphs(self):
+        db = grafeo.GrafeoDB()
+        extraction_with_alice = _extraction()
+
+        mgr_a = _make_manager(db, "graph_a", [extraction_with_alice])
+        mgr_b = _make_manager(db, "graph_b", [extraction_with_alice])
+
+        mgr_a.add("Alice works at Acme Corp")
+        mgr_b.add("Alice works at Acme Corp")
+
+        # Should have two separate "alice" entity nodes
+        entity_nodes = db.get_nodes_by_label(ENTITY_LABEL)
+        alice_nodes = [
+            (nid, props) for nid, props in entity_nodes
+            if props.get("name") == "alice"
+        ]
+        assert len(alice_nodes) == 2
+
+        graphs = {props.get("graph_name") for _, props in alice_nodes}
+        assert graphs == {"graph_a", "graph_b"}
+
+        mgr_a.close()
+        mgr_b.close()
+
+
+class TestGraphNameStats:
+    """stats() should return scoped counts when graph_name is set."""
+
+    def test_stats_scoped_to_graph(self):
+        db = grafeo.GrafeoDB()
+        mgr_a = _make_manager(db, "graph_a", [_extraction()])
+        mgr_b = _make_manager(db, "graph_b", [
+            _extraction(facts=["bob likes hiking"], entities=[{"name": "bob", "entity_type": "person"}], relations=[]),
+            _extraction(facts=["bob plays guitar"], entities=[{"name": "bob", "entity_type": "person"}], relations=[]),
+        ])
+
+        mgr_a.add("Alice works at Acme Corp")
+        mgr_b.add("Bob likes hiking")
+        mgr_b.add("Bob plays guitar")
+
+        stats_a = mgr_a.stats()
+        stats_b = mgr_b.stats()
+
+        assert stats_a.total_memories == 1
+        assert stats_b.total_memories == 2
+
+        # Entity counts should be scoped too
+        assert stats_a.entity_count == 2  # alice + acme_corp
+        assert stats_b.entity_count == 1  # bob
+
+        mgr_a.close()
+        mgr_b.close()
+
+    def test_stats_no_graph_name_counts_all(self):
+        db = grafeo.GrafeoDB()
+        mgr_a = _make_manager(db, "graph_a", [_extraction()])
+        mgr_b = _make_manager(db, "graph_b", [
+            _extraction(facts=["bob likes hiking"], entities=[{"name": "bob", "entity_type": "person"}], relations=[]),
+        ])
+        mgr_all = _make_manager(db, None, [])
+
+        mgr_a.add("Alice works at Acme Corp")
+        mgr_b.add("Bob likes hiking")
+
+        stats_all = mgr_all.stats()
+        assert stats_all.total_memories == 2
+
+        mgr_a.close()
+        mgr_b.close()
+        mgr_all.close()
+
+
+class TestGraphNameTemporalChain:
+    """temporal_chain should not cross graph boundaries."""
+
+    def test_temporal_chain_scoped(self):
+        db = grafeo.GrafeoDB()
+        mgr_a = _make_manager(db, "graph_a", [
+            _extraction(),
+            _extraction(facts=["alice got promoted"]),
+        ], run_id="session1")
+        mgr_b = _make_manager(db, "graph_b", [
+            _extraction(facts=["bob likes hiking"], entities=[{"name": "bob", "entity_type": "person"}], relations=[]),
+        ], run_id="session1")
+
+        events_a = mgr_a.add("Alice works at Acme Corp")
+        mgr_b.add("Bob likes hiking")
+        events_a2 = mgr_a.add("Alice got promoted")
+
+        # Get chain from graph_a's first memory
+        first_id = events_a[0].memory_id
+        chain = mgr_a.temporal_chain(first_id, user_id="test_user")
+
+        # Chain should only contain graph_a memories, not graph_b
+        chain_texts = [c["text"] for c in chain]
+        for text in chain_texts:
+            assert "bob" not in text.lower()
+
+        mgr_a.close()
+        mgr_b.close()
+
+
+class TestGraphNameBuildFilters:
+    """_build_filters should include graph_name when configured."""
+
+    def test_build_filters_with_graph_name(self):
+        db = grafeo.GrafeoDB()
+        mgr = _make_manager(db, "my_graph", [])
+        filters = mgr._build_filters("test_user")
+        assert filters["graph_name"] == "my_graph"
+        mgr.close()
+
+    def test_build_filters_without_graph_name(self):
+        db = grafeo.GrafeoDB()
+        mgr = _make_manager(db, None, [])
+        filters = mgr._build_filters("test_user")
+        assert "graph_name" not in filters
+        mgr.close()
+
+
+class TestGraphNameBackwardsCompat:
+    """Existing behavior unchanged when graph_name is not set."""
+
+    def test_default_config_has_no_graph_name(self):
+        config = MemoryConfig()
+        assert config.graph_name is None
+
+    def test_manager_without_graph_name_works(self):
+        db = grafeo.GrafeoDB()
+        mgr = _make_manager(db, None, [_extraction()])
+        events = mgr.add("Alice works at Acme Corp")
+        assert len(events) >= 1
+        assert events[0].action == MemoryAction.ADD
+
+        results = mgr.search("Alice", user_id="test_user")
+        assert len(results) >= 1
+        mgr.close()

--- a/tests/test_graph_name.py
+++ b/tests/test_graph_name.py
@@ -91,9 +91,15 @@ class TestGraphNameReadIsolation:
     def test_search_isolated_between_graphs(self):
         db = grafeo.GrafeoDB()
         mgr_a = _make_manager(db, "graph_a", [_extraction()])
-        mgr_b = _make_manager(db, "graph_b", [
-            _extraction(facts=["bob likes hiking"], entities=[{"name": "bob", "entity_type": "person"}], relations=[]),
-        ])
+        mgr_b = _make_manager(
+            db,
+            "graph_b",
+            [
+                _extraction(
+                    facts=["bob likes hiking"], entities=[{"name": "bob", "entity_type": "person"}], relations=[]
+                ),
+            ],
+        )
 
         mgr_a.add("Alice works at Acme Corp")
         mgr_b.add("Bob likes hiking")
@@ -118,9 +124,15 @@ class TestGraphNameReadIsolation:
     def test_get_all_isolated_between_graphs(self):
         db = grafeo.GrafeoDB()
         mgr_a = _make_manager(db, "graph_a", [_extraction()])
-        mgr_b = _make_manager(db, "graph_b", [
-            _extraction(facts=["bob likes hiking"], entities=[{"name": "bob", "entity_type": "person"}], relations=[]),
-        ])
+        mgr_b = _make_manager(
+            db,
+            "graph_b",
+            [
+                _extraction(
+                    facts=["bob likes hiking"], entities=[{"name": "bob", "entity_type": "person"}], relations=[]
+                ),
+            ],
+        )
 
         mgr_a.add("Alice works at Acme Corp")
         mgr_b.add("Bob likes hiking")
@@ -139,9 +151,15 @@ class TestGraphNameReadIsolation:
     def test_no_graph_name_sees_everything(self):
         db = grafeo.GrafeoDB()
         mgr_a = _make_manager(db, "graph_a", [_extraction()])
-        mgr_b = _make_manager(db, "graph_b", [
-            _extraction(facts=["bob likes hiking"], entities=[{"name": "bob", "entity_type": "person"}], relations=[]),
-        ])
+        mgr_b = _make_manager(
+            db,
+            "graph_b",
+            [
+                _extraction(
+                    facts=["bob likes hiking"], entities=[{"name": "bob", "entity_type": "person"}], relations=[]
+                ),
+            ],
+        )
         mgr_all = _make_manager(db, None, [])
 
         mgr_a.add("Alice works at Acme Corp")
@@ -170,10 +188,7 @@ class TestGraphNameEntityIsolation:
 
         # Should have two separate "alice" entity nodes
         entity_nodes = db.get_nodes_by_label(ENTITY_LABEL)
-        alice_nodes = [
-            (nid, props) for nid, props in entity_nodes
-            if props.get("name") == "alice"
-        ]
+        alice_nodes = [(nid, props) for nid, props in entity_nodes if props.get("name") == "alice"]
         assert len(alice_nodes) == 2
 
         graphs = {props.get("graph_name") for _, props in alice_nodes}
@@ -189,10 +204,18 @@ class TestGraphNameStats:
     def test_stats_scoped_to_graph(self):
         db = grafeo.GrafeoDB()
         mgr_a = _make_manager(db, "graph_a", [_extraction()])
-        mgr_b = _make_manager(db, "graph_b", [
-            _extraction(facts=["bob likes hiking"], entities=[{"name": "bob", "entity_type": "person"}], relations=[]),
-            _extraction(facts=["bob plays guitar"], entities=[{"name": "bob", "entity_type": "person"}], relations=[]),
-        ])
+        mgr_b = _make_manager(
+            db,
+            "graph_b",
+            [
+                _extraction(
+                    facts=["bob likes hiking"], entities=[{"name": "bob", "entity_type": "person"}], relations=[]
+                ),
+                _extraction(
+                    facts=["bob plays guitar"], entities=[{"name": "bob", "entity_type": "person"}], relations=[]
+                ),
+            ],
+        )
 
         mgr_a.add("Alice works at Acme Corp")
         mgr_b.add("Bob likes hiking")
@@ -214,9 +237,15 @@ class TestGraphNameStats:
     def test_stats_no_graph_name_counts_all(self):
         db = grafeo.GrafeoDB()
         mgr_a = _make_manager(db, "graph_a", [_extraction()])
-        mgr_b = _make_manager(db, "graph_b", [
-            _extraction(facts=["bob likes hiking"], entities=[{"name": "bob", "entity_type": "person"}], relations=[]),
-        ])
+        mgr_b = _make_manager(
+            db,
+            "graph_b",
+            [
+                _extraction(
+                    facts=["bob likes hiking"], entities=[{"name": "bob", "entity_type": "person"}], relations=[]
+                ),
+            ],
+        )
         mgr_all = _make_manager(db, None, [])
 
         mgr_a.add("Alice works at Acme Corp")
@@ -235,13 +264,25 @@ class TestGraphNameTemporalChain:
 
     def test_temporal_chain_scoped(self):
         db = grafeo.GrafeoDB()
-        mgr_a = _make_manager(db, "graph_a", [
-            _extraction(),
-            _extraction(facts=["alice got promoted"]),
-        ], run_id="session1")
-        mgr_b = _make_manager(db, "graph_b", [
-            _extraction(facts=["bob likes hiking"], entities=[{"name": "bob", "entity_type": "person"}], relations=[]),
-        ], run_id="session1")
+        mgr_a = _make_manager(
+            db,
+            "graph_a",
+            [
+                _extraction(),
+                _extraction(facts=["alice got promoted"]),
+            ],
+            run_id="session1",
+        )
+        mgr_b = _make_manager(
+            db,
+            "graph_b",
+            [
+                _extraction(
+                    facts=["bob likes hiking"], entities=[{"name": "bob", "entity_type": "person"}], relations=[]
+                ),
+            ],
+            run_id="session1",
+        )
 
         events_a = mgr_a.add("Alice works at Acme Corp")
         mgr_b.add("Bob likes hiking")

--- a/tests/test_graph_name.py
+++ b/tests/test_graph_name.py
@@ -9,7 +9,6 @@ import grafeo
 from mock_llm import MockEmbedder, make_test_model
 
 from grafeo_memory import MemoryAction, MemoryConfig, MemoryManager
-from grafeo_memory.search.vector import _get_props
 from grafeo_memory.types import ENTITY_LABEL, MEMORY_LABEL
 
 
@@ -246,7 +245,7 @@ class TestGraphNameTemporalChain:
 
         events_a = mgr_a.add("Alice works at Acme Corp")
         mgr_b.add("Bob likes hiking")
-        events_a2 = mgr_a.add("Alice got promoted")
+        mgr_a.add("Alice got promoted")
 
         # Get chain from graph_a's first memory
         first_id = events_a[0].memory_id

--- a/tests/test_graph_name.py
+++ b/tests/test_graph_name.py
@@ -77,7 +77,7 @@ class TestGraphNameWriteScoping:
     def test_batch_add_stamps_graph_name(self):
         db = grafeo.GrafeoDB()
         mgr = _make_manager(db, "batch_graph", [_extraction()])
-        mgr.add("Alice works at Acme Corp", infer=False)
+        mgr.add_batch(["Alice works at Acme Corp", "Bob likes hiking"], infer=False)
 
         for _nid, props in db.get_nodes_by_label(MEMORY_LABEL):
             assert props.get("graph_name") == "batch_graph"


### PR DESCRIPTION
Release round up and @Michaelzag's fix for #23 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add optional `graph_name` scoping to `MemoryConfig` to isolate data when multiple `MemoryManager` instances share a DB. Also updates the 0.2.2 changelog and applies ruff formatting.

- **New Features**
  - Added `graph_name: str | None` to `MemoryConfig`.
  - Stamp `graph_name` on `Memory` and `Entity` nodes (incl. `add_batch`).
  - Apply `graph_name` in filters and queries: search (incl. 2‑hop), stats, temporal_chain, session chain links, and entity lookup/creation.
  - Added a property index for `graph_name` to speed scoped lookups.
  - Added isolation tests to ensure graphs don’t bleed into each other.

- **Bug Fixes**
  - Scoped `e1`, `e2`, and `m` in the 2‑hop graph search by `graph_name`.
  - Fixed test to call `add_batch`; minor lint fixes and ruff formatting; finalized CHANGELOG for 0.2.2.

<sup>Written for commit 37c02ce642da411d20f785f20f27aed0ab7d1c90. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

